### PR TITLE
workaround: make types work with latest fastify

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "fp-ts": "^2.11.2",
     "standard": "^17.0.0",
     "tap": "^16.3.0",
-    "tsd": "^0.20.0"
+    "tsd": "^0.30.0"
   },
   "homepage": "https://github.com/fastify/fastify-funky",
   "repository": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,31 +1,4 @@
 import { FastifyPluginCallback } from 'fastify'
-import {
-  ContextConfigDefault,
-  RawReplyDefaultExpression,
-  RawRequestDefaultExpression,
-  RawServerBase,
-  RawServerDefault,
-} from 'fastify/types/utils'
-import { FastifyInstance } from 'fastify/types/instance'
-import { FastifyRequest } from 'fastify/types/request'
-import { FastifyReply } from 'fastify/types/reply'
-import { RouteGenericInterface } from 'fastify/types/route'
-
-declare module 'fastify' {
-  interface RouteHandlerMethod<
-    RawServer extends RawServerBase = RawServerDefault,
-    RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
-    RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-    RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
-    ContextConfig = ContextConfigDefault
-  > {
-    (
-      this: FastifyInstance<RawServer, RawRequest, RawReply>,
-      request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
-      reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>
-    ): void | Promise<RouteGeneric['Reply'] | void> | fastifyFunky.FunkyReply<RouteGeneric['Reply']>
-  }
-}
 
 type FastifyFunky = FastifyPluginCallback
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance, FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify'
 import fastify from 'fastify'
 import { either, task, taskEither } from 'fp-ts'
-import { expectType, expectError } from 'tsd'
+import { expectType, expectError, expectAssignable } from 'tsd'
 
 import { fastifyFunky as fastifyFunkyNamed } from '..'
 import fastifyFunkyDefault from '..'
@@ -32,49 +32,59 @@ app.get('/', (req: FastifyRequest, reply: FastifyReply) => {
   return { right: { id: 1 } }
 })
 
-app.get('/func', (req: FastifyRequest, reply: FastifyReply) => {
+app.get('/func', (req, reply) => {
+  expectAssignable<FastifyRequest>(req)
+  expectAssignable<FastifyReply>(reply)
   return () => {
     return { right: { id: 1 } }
   }
 })
 
-app.get('/func', (req: FastifyRequest, reply: FastifyReply) => {
+app.get('/func', (req, reply) => {
+  expectAssignable<FastifyRequest>(req)
+  expectAssignable<FastifyReply>(reply)
   return Promise.resolve({})
 })
 
-app.get('/func', (req: FastifyRequest, reply: FastifyReply) => {
+app.get('/func', (req, reply) => {
+  expectAssignable<FastifyRequest>(req)
+  expectAssignable<FastifyReply>(reply)
   reply.status(200).send({})
 })
 
 // this is allowed
 app.get("/", (req, reply) => {
+  expectAssignable<FastifyRequest>(req)
+  expectAssignable<FastifyReply>(reply)
   return { right: { id: 1 } };
 });
 app.get("/", (req, reply) => {
+  expectAssignable<FastifyRequest>(req)
+  expectAssignable<FastifyReply>(reply)
   return { left: new Error('error') };
 });
 app.get("/", (req, reply) => {
+  expectAssignable<FastifyRequest>(req)
+  expectAssignable<FastifyReply>(reply)
   return taskEither.fromEither(either.left(new Error('Invalid state')))
 });
 app.get("/", (req, reply) => {
+  expectAssignable<FastifyRequest>(req)
+  expectAssignable<FastifyReply>(reply)
   return taskEither.fromTask(task.of(Promise.resolve({})))
 });
 app.get("/", (req, reply) => {
+  expectAssignable<FastifyRequest>(req)
+  expectAssignable<FastifyReply>(reply)
   return either.of(Promise.resolve({}))
 });
 app.get("/", (req, reply) => {
+  expectAssignable<FastifyRequest>(req)
+  expectAssignable<FastifyReply>(reply)
   return task.of(Promise.resolve({}))
 });
 app.get("/", (req, reply) => {
+  expectAssignable<FastifyRequest>(req)
+  expectAssignable<FastifyReply>(reply)
   return taskEither.of(Promise.resolve({}))
 });
-
-//this will actually work in js, but not encouraged and hence ts will throw an error
-expectError(app.get("/", (req, reply) => {
-  return {}
-}))
-
-// ...but this gives a (correct) type error
-expectError(app.get('/', (req: FastifyRequest, reply: FastifyReply) => {
-  return { rght: { id: 1 } }
-}))


### PR DESCRIPTION
It does not fix the underlying issue but it makes it work again with latest fastify 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
