### PR TITLE
refactor: migrate from tap to node:test

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,0 @@
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "types": "types/index.d.ts",
   "scripts": {
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
+    "test:unit": "c8 --100 node --test",
     "test:typescript": "tsd",
     "lint": "standard"
   },
@@ -24,10 +24,10 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^20.1.0",
+    "c8": "^10.1.2",
     "fastify": "^5.0.0-alpha.4",
     "fp-ts": "^2.11.2",
     "standard": "^17.0.0",
-    "tap": "^21.0.0",
     "tsd": "^0.31.1"
   },
   "homepage": "https://github.com/fastify/fastify-funky",

--- a/test/funkyPlugin.test.js
+++ b/test/funkyPlugin.test.js
@@ -2,7 +2,7 @@
 
 const fastify = require('fastify')
 const { either, task, taskEither } = require('fp-ts')
-const { test } = require('tap')
+const { test } = require('node:test')
 const {
   initAppGet,
   assertResponseTypeAndBody,
@@ -27,7 +27,7 @@ test('Promise: Correctly handles top-level promise', async (t) => {
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -43,7 +43,7 @@ test('either: correctly parses right part of Either (sync)', async (t) => {
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -60,7 +60,7 @@ test('either: correctly parses right part of Either (async)', async (t) => {
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -77,7 +77,7 @@ test('either: correctly parses left part of Either when resolved (async)', async
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -93,7 +93,7 @@ test('either: correctly parses left part of Either when resolved (sync)', async 
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -113,7 +113,7 @@ test('either: supports reply callback with the right part of Either', async (t) 
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -129,7 +129,7 @@ test('task: correctly parses Task result (sync)', async (t) => {
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -145,7 +145,7 @@ test('task: correctly parses Task result (promise)', async (t) => {
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -165,7 +165,7 @@ test('task: correctly handles Task throwing', async (t) => {
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -185,7 +185,7 @@ test('task: correctly parses result of a plain parameterless function', async (t
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -205,7 +205,7 @@ test('task: correctly parses result of a plain parameterless function that retur
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -225,7 +225,7 @@ test('task: ignores parameterless function with parameters', async (t) => {
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -241,7 +241,7 @@ test('task: handles empty body correctly', async (t) => {
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -256,7 +256,7 @@ test('text content: correctly handles text response', async (t) => {
 
   const app = fastify().register(fastifyFunky)
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -290,7 +290,7 @@ test('taskEither: correctly parses TaskEither result (Either right)', async (t) 
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -306,7 +306,7 @@ test('taskEither: correctly parses TaskEither result (Task)', async (t) => {
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 
@@ -322,7 +322,7 @@ test('taskEither: correctly parses TaskEither result (Either left)', async (t) =
 
   const app = await initAppGet(t, route).ready()
 
-  t.teardown(() => {
+  t.after(() => {
     app.close()
   })
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -11,7 +11,7 @@ function initAppGet (t, endpoint) {
 
   app.setErrorHandler((error, request, reply) => {
     app.log.error(error)
-    t.strictSame(error.message, 'Invalid state')
+    t.assert.deepStrictEqual(error.message, 'Invalid state')
     reply.status(500).send({ ok: false })
   })
 
@@ -20,8 +20,8 @@ function initAppGet (t, endpoint) {
 
 async function assertResponseTypeAndBody (t, app, endpoint, expectedType, expectedBody) {
   const response = await app.inject().get(endpoint).end()
-  t.strictSame(response.headers['content-type'], expectedType)
-  t.strictSame(response.body, expectedBody)
+  t.assert.deepStrictEqual(response.headers['content-type'], expectedType)
+  t.assert.deepStrictEqual(response.body, expectedBody)
 }
 
 function assertCorrectResponse (t, app) {
@@ -30,8 +30,8 @@ function assertCorrectResponse (t, app) {
     .get('/')
     .end()
     .then((response) => {
-      t.strictSame(response.statusCode, 200)
-      t.strictSame(response.json().user, { id: 1 })
+      t.assert.deepStrictEqual(response.statusCode, 200)
+      t.assert.deepStrictEqual(response.json().user, { id: 1 })
     })
 }
 
@@ -41,8 +41,8 @@ function assertCorrectResponseBody (t, app, expectedBody, expectedCode = 200) {
     .get('/')
     .end()
     .then((response) => {
-      t.strictSame(response.statusCode, expectedCode)
-      t.strictSame(response.body, expectedBody)
+      t.assert.deepStrictEqual(response.statusCode, expectedCode)
+      t.assert.deepStrictEqual(response.body, expectedBody)
     })
 }
 
@@ -52,8 +52,8 @@ function assertErrorResponse (t, app) {
     .get('/')
     .end()
     .then((response) => {
-      t.strictSame(response.statusCode, 500)
-      t.strictSame(response.json(), {
+      t.assert.deepStrictEqual(response.statusCode, 500)
+      t.assert.deepStrictEqual(response.json(), {
         ok: false
       })
     })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Removes `tap` and uses `node:test`. 

https://github.com/fastify/fastify/issues/5555



#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
